### PR TITLE
refactor: split `on_error` and `on_complete` from `subscribe` method

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -4,6 +4,6 @@ workflow "Build and Publish on push" {
 }
 
 action "build-and-test" {
-  uses = "docker://rustlang/rust:nightly"
-  runs = ["sh", "-c", "rustup component add rustfmt && cargo fmt -- --check && rustup component add clippy && cargo clippy -- -Dwarnings && cargo test"]
+  uses = "docker://rust:1.35"
+  runs = ["sh", "-c", "rustup toolchain install nightly && rustup component add rustfmt --toolchain nightly && cargo +nightly fmt -- --check && rustup component add clippy && cargo clippy -- -Dwarnings && cargo test"]
 }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ rx_rs ia a Rust implementation of Reactive Extensions. Which is almost zero cost
 ```rust
 use rx_rs::{ 
   ops::{ Filter, Merge }, Observable, Observer,
-  Subject, Subscription, ErrComplete 
+  Subject, Subscription 
 };
 
 let numbers = Subject::new();
@@ -20,12 +20,9 @@ let odd = numbers.clone().filter(|v| *v % 2 != 0);
 let merged = even.merge(odd);
 
 // attach observers
-let subscription = merged.subscribe(
-  |v| println!("{} ", v),
-  |ec: &ErrComplete<()>| {
-    // process Error or Complete here.
-  }
-);
+let subscription = merged
+  .subscribe(|v| print!("{} ", v))
+  .on_error(|e| println!("Error because of: {}", e));
 
 // shot numbers
 (0..10).into_iter().for_each(|v| {
@@ -34,6 +31,6 @@ let subscription = merged.subscribe(
 
 // "0 1 2 3 4 5 6 7 8 9" will be print.
 
-// unsubscribe the stream.
-subscription.unsubscribe();
+// "Error because of: just trigger an error."
+numbers.error("just trigger an error.");
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,15 +9,14 @@ pub use subject::Subject;
 pub trait Observable<'a>: Sized {
   /// The type of the elements being emitted.
   type Item: Sized;
-  /// The type of error may occur.
+  //
   type Err;
   // the Subscription subsribe method return.
-  type Unsubscribe: Subscription;
+  type Unsubscribe: Subscription<'a, Err = Self::Err>;
 
-  fn subscribe<N, EC>(self, next: N, err_or_complete: EC) -> Self::Unsubscribe
+  fn subscribe<N>(self, next: N) -> Self::Unsubscribe
   where
-    N: 'a + Fn(Self::Item),
-    EC: 'a + Fn(&ErrComplete<Self::Err>);
+    N: 'a + Fn(Self::Item);
 
   fn broadcast(self) -> Subject<'a, Self::Item, Self::Err>
   where
@@ -35,14 +34,16 @@ pub trait Observer {
 
   fn complete(self);
 
-  fn err(self, err: Self::Err);
+  fn error(self, err: Self::Err);
 }
 
-pub trait Subscription {
+pub trait Subscription<'a> {
+  type Err;
+  fn on_error<E>(&mut self, err: E) -> &mut Self
+  where
+    E: Fn(&Self::Err) + 'a;
+  fn on_complete<C>(&mut self, complete: C) -> &mut Self
+  where
+    C: Fn() + 'a;
   fn unsubscribe(self);
-}
-
-pub enum ErrComplete<E> {
-  Complete,
-  Err(E),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-#![feature(external_doc)]
-#![doc(include = "../README.md")]
+#![cfg_attr(feature = "nightly", feature(external_doc))]
+#![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
 
 pub mod ops;
 pub mod subject;

--- a/src/ops/filter.rs
+++ b/src/ops/filter.rs
@@ -1,21 +1,20 @@
-use crate::{ErrComplete, Observable};
+use crate::Observable;
 
 /// Emit only those items from an Observable that pass a predicate test
 /// # Example
 ///
 /// ```
-/// use rx_rs::{ops::Filter, Subject, Observable, Observer, ErrComplete};
+/// use rx_rs::{ops::Filter, Subject, Observable, Observer};
 /// use std::cell::RefCell;
 /// use std::rc::Rc;
 ///
-/// let subject = Subject::new();
+/// let subject = Subject::<'_, _, ()>::new();
 /// let coll = Rc::new(RefCell::new(vec![]));
 /// let coll_clone = coll.clone();
 ///
 /// subject.clone().filter(|v| *v % 2 == 0).subscribe(move |v| {
 ///    coll_clone.borrow_mut().push(*v);
-/// },
-/// |ec: &ErrComplete<()>| {});
+/// });
 
 /// (0..10).into_iter().for_each(|v| {
 ///    subject.next(v);
@@ -50,23 +49,19 @@ where
   S: Observable<'a>,
   F: 'a + Fn(&S::Item) -> bool,
 {
+  type Err = S::Err;
   type Item = S::Item;
   type Unsubscribe = S::Unsubscribe;
-  type Err = S::Err;
 
-  fn subscribe<N, EC>(self, next: N, err_or_complete: EC) -> Self::Unsubscribe
+  fn subscribe<N>(self, next: N) -> Self::Unsubscribe
   where
     N: 'a + Fn(Self::Item),
-    EC: 'a + Fn(&ErrComplete<Self::Err>),
   {
     let filter = self.filter;
-    self.source.subscribe(
-      move |v| {
-        if filter(&v) {
-          next(v);
-        }
-      },
-      err_or_complete,
-    )
+    self.source.subscribe(move |v| {
+      if filter(&v) {
+        next(v);
+      }
+    })
   }
 }

--- a/src/ops/map.rs
+++ b/src/ops/map.rs
@@ -1,4 +1,4 @@
-use crate::{ErrComplete, Observable};
+use crate::Observable;
 
 /// Creates a new stream which calls a closure on each element and uses
 /// its return as the value.
@@ -29,39 +29,30 @@ where
   M: Fn(S::Item) -> B + 'a,
 {
   type Item = B;
-  type Unsubscribe = S::Unsubscribe;
   type Err = S::Err;
+  type Unsubscribe = S::Unsubscribe;
 
-  fn subscribe<N, EC>(self, next: N, err_or_complete: EC) -> Self::Unsubscribe
+  fn subscribe<N>(self, next: N) -> Self::Unsubscribe
   where
     N: 'a + Fn(Self::Item),
-    EC: 'a + Fn(&ErrComplete<Self::Err>),
   {
     let func = self.func;
-    self.source.subscribe(
-      move |v| {
-        next(func(v));
-      },
-      err_or_complete,
-    )
+    self.source.subscribe(move |v| {
+      next(func(v));
+    })
   }
 }
 
 #[cfg(test)]
 mod test {
-  use crate::{
-    ops::Map, ErrComplete, Observable, Observer, Subject, Subscription,
-  };
+  use crate::{ops::Map, Observable, Observer, Subject, Subscription};
   use std::cell::Cell;
 
   #[test]
   fn primitive_type() {
     let i = Cell::new(0);
-    let subject = Subject::new();
-    subject
-      .clone()
-      .map(|v| v * 2)
-      .subscribe(|v| i.set(v), |_: &ErrComplete<()>| {});
+    let subject = Subject::<'_, i32, ()>::new();
+    subject.clone().map(|v| v * 2).subscribe(|v| i.set(v));
     subject.next(100);
     assert_eq!(i.get(), 200);
   }
@@ -69,11 +60,8 @@ mod test {
   #[test]
   fn reference_lifetime_should_work() {
     let i = Cell::new(0);
-    let subject = Subject::new();
-    subject
-      .clone()
-      .map(|v: &&i32| v)
-      .subscribe(|v| i.set(**v), |_: &ErrComplete<()>| {});
+    let subject = Subject::<'_, &i32, ()>::new();
+    subject.clone().map(|v: &&i32| v).subscribe(|v| i.set(**v));
     subject.next(&100);
     assert_eq!(i.get(), 100);
   }
@@ -81,11 +69,11 @@ mod test {
   #[test]
   fn unsubscribe() {
     let i = Cell::new(0);
-    let subject = Subject::new();
+    let subject = Subject::<'_, &i32, ()>::new();
     subject
       .clone()
       .map(|v: &&i32| v)
-      .subscribe(|v| i.set(**v), |_: &ErrComplete<()>| {})
+      .subscribe(|v| i.set(**v))
       .unsubscribe();
     subject.next(&100);
     assert_eq!(i.get(), 0);

--- a/src/subject.rs
+++ b/src/subject.rs
@@ -10,6 +10,7 @@ pub(crate) struct Callbacks<'a, T, E> {
   on_error: Option<Box<Fn(&E) + 'a>>,
 }
 
+#[derive(Default)]
 pub struct Subject<'a, T, E> {
   cbs: Rc<RefCell<Vec<Callbacks<'a, T, E>>>>,
 }


### PR DESCRIPTION
Now use `rx_rs` in this way:
```rust
  subject
    .map(...)
    .filter(...)
    .subscribe(|v| { ... })
    // if need error handding
    .on_error(|err| { ... })
    // completed process, if need
    .on_complete(|| { ... });
```